### PR TITLE
fixed dead link to compose key option list

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ Using the tray icon menu (right click) you can access this help file, and the co
 Compose Key Table
 -----------------
 
-These are the various Linux [compose key options](http://hermit.org/Linux/ComposeKeys.html), all 385 of them!
+These are the various Linux [compose key options](https://tstarling.com/stuff/ComposeKeys.html), all 385 of them!


### PR DESCRIPTION
The page at hermit.org leads to a 404